### PR TITLE
Feature/escape javascript arguments

### DIFF
--- a/lib/capybara_js_helpers.rb
+++ b/lib/capybara_js_helpers.rb
@@ -3,32 +3,18 @@ require 'capybara_js_helpers/sweet_alert_helper.rb'
 require 'capybara_js_helpers/ck_editor_helper.rb'
 
 module CapybaraJsHelpers
-  # Adapted from action_view/helpers/javascript_helper.rb
-  JS_ESCAPE_MAP = {
-    '\\'    => '\\\\',
-    "</"    => '<\/',
-    "\r\n"  => '\n',
-    "\n"    => '\n',
-    "\r"    => '\n',
-    '"'     => '\\"',
-    "'"     => "\\'",
-    "`"     => "\\`",
-    "$"     => "\\$"
-  }
+  def self.execute_script(javascript, **variables)
+    definitions = []
+    arguments = []
 
-  JS_ESCAPE_MAP[(+"\342\200\250").force_encoding(Encoding::UTF_8).encode!] = "&#x2028;"
-  JS_ESCAPE_MAP[(+"\342\200\251").force_encoding(Encoding::UTF_8).encode!] = "&#x2029;"
+    variables.each_with_index do |(var, value), index|
+      definitions << "var #{var} = arguments[#{index}];"
+      arguments << value
+    end
 
-  def self.escape_javascript(javascript)
-    javascript = javascript.to_s
-    return "" if javascript.empty?
-
-    javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"']|[`]|[$])/u, JS_ESCAPE_MAP)
-  end
-
-  def self.execute_script(javascript, **interpolations)
     Capybara.current_session.execute_script(
-      escape_javascript(javascript % interpolations)
+      "#{definitions.join("\n")}\n#{javascript}",
+      *arguments
     )
   end
 end

--- a/lib/capybara_js_helpers.rb
+++ b/lib/capybara_js_helpers.rb
@@ -1,3 +1,34 @@
 require 'capybara_js_helpers/selectize_helper.rb'
 require 'capybara_js_helpers/sweet_alert_helper.rb'
 require 'capybara_js_helpers/ck_editor_helper.rb'
+
+module CapybaraJsHelpers
+  # Adapted from action_view/helpers/javascript_helper.rb
+  JS_ESCAPE_MAP = {
+    '\\'    => '\\\\',
+    "</"    => '<\/',
+    "\r\n"  => '\n',
+    "\n"    => '\n',
+    "\r"    => '\n',
+    '"'     => '\\"',
+    "'"     => "\\'",
+    "`"     => "\\`",
+    "$"     => "\\$"
+  }
+
+  JS_ESCAPE_MAP[(+"\342\200\250").force_encoding(Encoding::UTF_8).encode!] = "&#x2028;"
+  JS_ESCAPE_MAP[(+"\342\200\251").force_encoding(Encoding::UTF_8).encode!] = "&#x2029;"
+
+  def self.escape_javascript(javascript)
+    javascript = javascript.to_s
+    return "" if javascript.empty?
+
+    javascript.gsub(/(\\|<\/|\r\n|\342\200\250|\342\200\251|[\n\r"']|[`]|[$])/u, JS_ESCAPE_MAP)
+  end
+
+  def self.execute_script(javascript, **interpolations)
+    Capybara.current_session.execute_script(
+      escape_javascript(javascript % interpolations)
+    )
+  end
+end

--- a/lib/capybara_js_helpers/ck_editor_helper.rb
+++ b/lib/capybara_js_helpers/ck_editor_helper.rb
@@ -3,8 +3,8 @@ module CapybaraJsHelpers
     def ckeditor_fill_in(locator, with:)
       CapybaraJsHelpers.execute_script <<-SCRIPT, locator: locator, content: with
         $(function() {
-          CKEDITOR.instances['%{locator}'].setData('%{content}');
-          $('textarea#%{locator}').text('%{content}');
+          CKEDITOR.instances[locator].setData(content);
+          $('textarea#' + locator).text(content);
         });
       SCRIPT
     end

--- a/lib/capybara_js_helpers/ck_editor_helper.rb
+++ b/lib/capybara_js_helpers/ck_editor_helper.rb
@@ -1,12 +1,11 @@
 module CapybaraJsHelpers
   module CkEditorHelper
-    def ckeditor_fill_in(locator, opts)
-      content = opts.fetch(:with).to_json
-      page.execute_script <<-SCRIPT
-      $(function() {
-        CKEDITOR.instances['#{locator}'].setData('#{content}');
-        $('textarea##{locator}').text('#{content}');
-      });
+    def ckeditor_fill_in(locator, with:)
+      CapybaraJsHelpers.execute_script <<-SCRIPT, locator: locator, content: with
+        $(function() {
+          CKEDITOR.instances['%{locator}'].setData('%{content}');
+          $('textarea#%{locator}').text('%{content}');
+        });
       SCRIPT
     end
   end

--- a/lib/capybara_js_helpers/selectize_helper.rb
+++ b/lib/capybara_js_helpers/selectize_helper.rb
@@ -2,7 +2,7 @@ module CapybaraJsHelpers
   module SelectizeHelper
     def selectize_add_item(selector, item_value)
       selectize_exec(
-        "addItem('%{item_value}')",
+        "addItem(item_value)",
         selector: selector,
         item_value: item_value
       )
@@ -10,7 +10,7 @@ module CapybaraJsHelpers
 
     def selectize_remove_item(selector, item_value)
       selectize_exec(
-        "removeItem('%{item_value}')",
+        "removeItem(item_value)",
         selector: selector,
         item_value: item_value
       )
@@ -18,7 +18,7 @@ module CapybaraJsHelpers
 
     def selectize_search(selector, search_term)
       selectize_exec(
-        "onSearchChange('%{search_term}')",
+        "onSearchChange(search_term)",
         selector: selector,
         search_term: search_term
       )
@@ -27,7 +27,7 @@ module CapybaraJsHelpers
 
     def selectize_exec(command, **options)
       CapybaraJsHelpers.execute_script(
-        "$('%{selector}')[0].selectize.#{command}",
+        "$(selector)[0].selectize.#{command}",
         **options
       )
     end

--- a/lib/capybara_js_helpers/selectize_helper.rb
+++ b/lib/capybara_js_helpers/selectize_helper.rb
@@ -1,20 +1,35 @@
 module CapybaraJsHelpers
   module SelectizeHelper
     def selectize_add_item(selector, item_value)
-      selectize_exec(selector, "addItem('#{item_value}')")
+      selectize_exec(
+        "addItem('%{item_value}')",
+        selector: selector,
+        item_value: item_value
+      )
     end
 
     def selectize_remove_item(selector, item_value)
-      selectize_exec(selector, "removeItem('#{item_value}')")
+      selectize_exec(
+        "removeItem('%{item_value}')",
+        selector: selector,
+        item_value: item_value
+      )
     end
 
     def selectize_search(selector, search_term)
-      selectize_exec(selector, "onSearchChange('#{search_term}')")
-      selectize_exec(selector, "open()")
+      selectize_exec(
+        "onSearchChange('%{search_term}')",
+        selector: selector,
+        search_term: search_term
+      )
+      selectize_exec("open()", selector: selector)
     end
 
-    def selectize_exec(selector, command)
-      page.execute_script("$('#{selector}')[0].selectize.#{command}")
+    def selectize_exec(command, **options)
+      CapybaraJsHelpers.execute_script(
+        "$('%{selector}')[0].selectize.#{command}",
+        **options
+      )
     end
   end
 end


### PR DESCRIPTION
Should fix issues with tests being flaky due to passed arguments having JS special characters in them - e.g. passing a Faker-generated name like "O'Leary"